### PR TITLE
remove relative path as this will break building as submodule

### DIFF
--- a/src/scss/shards.scss
+++ b/src/scss/shards.scss
@@ -6,7 +6,7 @@
  */
 
 // Bootstrap 4 dependencies
-@import "../../node_modules/bootstrap/scss/functions";
+@import "node_modules/bootstrap/scss/functions";
 
 // Core
 @import "mixins";


### PR DESCRIPTION
The relative path will cause this error:

Module build failed:
@import "../../node_modules/bootstrap/scss/functions";
^
      File to import not found or unreadable: ../../node_modules/bootstrap/scss/functions.
Parent style sheet: /Users/lucian/...../shards-ui/src/scss/shards.scss
      in /Users/lucian/...../shards-ui/src/scss/shards.scss (line 9, column 1)

This happens because when used as a submodule, the relative path does
not work anymore.

The fix isn't ideal as it assumes project root is within search path.

Fixes #18 