### PR TITLE
Fix append and prepend input group incorrect z-index

### DIFF
--- a/src/scss/_input-group.scss
+++ b/src/scss/_input-group.scss
@@ -41,7 +41,7 @@
       position: absolute;
       top: 0;
       bottom: 0;
-      z-index: $zindex-sticky;
+      z-index: 4;
 
       .input-group-text {
         padding: $input-group-padding-y $input-group-padding-x;


### PR DESCRIPTION
The z-index value needs to be higher than 3 because this is the value set by Bootstrap for `:focus` on `input-group` elements.

![image](https://user-images.githubusercontent.com/1061516/36340017-e4b796fe-13da-11e8-919e-90a7a7647b26.png)

### Current Behavior

![z-index-current-behavior](https://user-images.githubusercontent.com/1061516/36340004-9f79d1ce-13da-11e8-9370-dd4fd559dad6.gif)

### PR Behavior

![z-index-pr-behavior](https://user-images.githubusercontent.com/1061516/36340003-9d0896d2-13da-11e8-8798-1361675c3bd0.gif)

Fixes DesignRevision/shards-ui/issues/20