### PR TITLE
$popover-arrow-outer-width should have calc()

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -756,7 +756,7 @@ $popover-arrow-width:                 10px !default;
 $popover-arrow-height:                5px !default;
 $popover-arrow-color:                 $popover-bg !default;
 
-$popover-arrow-outer-width:           $popover-arrow-width + 1px !default;
+$popover-arrow-outer-width:           calc($popover-arrow-width + 1px) !default;
 $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !default;
 
 


### PR DESCRIPTION
I'm currently using the latest update of this library. However, I found an issue while using the scss, `create-react-app` is throwing an error on the line `759`. I had a look and I saw that is missing the `calc` function.