### PR TITLE
Mark $google-fonts-import as !default in variables

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -185,7 +185,7 @@ $transition-collapse:     height 350ms ease-in-out !default;
 
 // Fonts
 
-$google-fonts-import: 'https://fonts.googleapis.com/css?family=Poppins:300,400,500,600|Roboto+Mono'; // Includes: Poppins: Light, Regular, Medium, Semi-bold; Roboto Mono: Regular
+$google-fonts-import: 'https://fonts.googleapis.com/css?family=Poppins:300,400,500,600|Roboto+Mono' !default; // Includes: Poppins: Light, Regular, Medium, Semi-bold; Roboto Mono: Regular
 
 $font-family-poppins-first: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !default;
 $font-family-system-first: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !default;


### PR DESCRIPTION
Hey everyone,

it would be nice to have the shard-special variable `$google-fonts-import` marked as well with `!default` so that you can easily use other Google based fonts.

Thanks for your work