### PR TITLE
Add npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,31 @@
+# Generated files
+.DS_Store
+
+# node_modules
+node_modules
+
+# Configs
+.editorconfig
+.gitignore
+.npmignore
+
+# Repo related files
+/logo.png
+/ATTRIB.md
+/CHANGELOG.md
+/CONTRIBUTING.md
+/ISSUE_TEMPLATE.md
+
+# Lockfiles
+npm-shrinkwrap.json
+package-lock.json
+yarn.lock
+
+# Source files
+/src
+
+# Builder files
+/build
+
+# Logs
+*.log


### PR DESCRIPTION
`.npmignore` is used to tell `npm` what not to include in your package when installed as a dependency. Anything specifically related to the repo should be removed (i.e. `logo.png` or `CONTRIBUTING.md`) to reduce package size. Configs, `node_modules`, and `src` files as well (since users should be using `dist`).

This will help to reduce the package size and get faster installs.