### PR TITLE
Slider-handle: wrong value for 'right' property

### DIFF
--- a/src/scss/_custom-sliders.scss
+++ b/src/scss/_custom-sliders.scss
@@ -75,7 +75,7 @@ html:not([dir="rtl"]) {
     }
 
     .noUi-handle {
-      right: -17px;
+      right: -11.5px;
       left: auto;
     }
   }


### PR DESCRIPTION
Based on : https://github.com/DesignRevision/shards-ui/blob/master/src/scss/_variables.scss#L946
23 px / 2 = 11.5 px