### PR TITLE
Make "bundlesize" a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,10 +67,10 @@
     "uglify-js": "^3.3.23",
     "webpack": "^3.11.0",
     "bootstrap-datepicker": "^1.8.0",
-    "nouislider": "^11.1.0"
+    "nouislider": "^11.1.0",
+    "bundlesize": "^0.17.0"
   },
   "dependencies": {
-    "bootstrap": "4.1.3",
-    "bundlesize": "^0.17.0"
+    "bootstrap": "4.1.3"
   }
 }


### PR DESCRIPTION
"bundlesize" has an the following dependencies: "brotli-size" > "iltorb".

"iltorb" crashes often when trying to compile, but that's not the problem.
The problem is that "bundlesize" should be a dev dependency and not a normal one. That means it shouldn't even be downloaded by 90% of users.