### PR TITLE
remove tags from comment

### DIFF
--- a/src/scss/_reboot.scss
+++ b/src/scss/_reboot.scss
@@ -47,7 +47,7 @@ b, strong {
 
 // Remove top margins from headings
 //
-// By default, `<h1>`-`<h6>` all receive top and bottom margins. We nuke the top
+// By default, h1-h6 all receive top and bottom margins. We nuke the top
 // margin for easier control within type scales as it avoids margin collapsing.
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;


### PR DESCRIPTION
For some reason chrome doesn't like jekyll's generated map files when it contains the tags I removed.

`DevTools failed to load SourceMap: Could not parse content for static/css/main.css.map: Unexpected token in JSON at position 71464`