### PR TITLE
Fix division warning

### DIFF
--- a/src/scss/_card.scss
+++ b/src/scss/_card.scss
@@ -61,7 +61,7 @@
 }
 
 .card-subtitle {
-  margin-top: -($card-spacer-y / 2);
+  margin-top: -($card-spacer-y * 0.5);
 }
 
 .card-link {
@@ -112,8 +112,8 @@
 }
 
 .card-header-pills {
-  margin-right: -($card-spacer-x / 2);
-  margin-left: -($card-spacer-x / 2);
+  margin-right: -($card-spacer-x * 0.5);
+  margin-left: -($card-spacer-x * 0.5);
 
   &:hover {
     background: transparent;

--- a/src/scss/_carousel.scss
+++ b/src/scss/_carousel.scss
@@ -57,7 +57,7 @@
 
 // Optional captions
 .carousel-caption {
-  right: ((100% - $carousel-caption-width) / 2);
-  left: ((100% - $carousel-caption-width) / 2);
+  right: ((100% - $carousel-caption-width) * 0.5);
+  left: ((100% - $carousel-caption-width) * 0.5);
   color: $carousel-caption-color;
 }

--- a/src/scss/_custom-forms.scss
+++ b/src/scss/_custom-forms.scss
@@ -67,7 +67,7 @@
 
   // Background-color and (when enabled) gradient
   &::before {
-    top: (($line-height-base - $custom-control-indicator-size) / 2);
+    top: (($line-height-base - $custom-control-indicator-size) * 0.5);
     left: 0;
     width: $custom-control-indicator-size;
     height: $custom-control-indicator-size;
@@ -79,7 +79,7 @@
 
   // Foreground (icon)
   &::after {
-    top: (($line-height-base - $custom-control-indicator-size) / 2);
+    top: (($line-height-base - $custom-control-indicator-size) * 0.5);
     width: $custom-control-indicator-size;
     height: $custom-control-indicator-size;
     background-size: $custom-control-indicator-bg-size;

--- a/src/scss/_custom-sliders.scss
+++ b/src/scss/_custom-sliders.scss
@@ -104,7 +104,7 @@ html:not([dir="rtl"]) {
 
   .noUi-handle {
     left: -10px;
-    top: -$slider-handle-width / 2;
+    top: -$slider-handle-width * 0.5;
 
     &:before,
     &:after {
@@ -140,7 +140,7 @@ html:not([dir="rtl"]) {
   }
 
   .noUi-handle {
-    left: -$slider-handle-width / 2;
+    left: -$slider-handle-width * 0.5;
     top: -10px;
   }
 

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -54,7 +54,7 @@
   $g: green($color);
   $b: blue($color);
 
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) * 0.001;
 
   @if ($yiq >= 150) {
     color: darken($color, 65);

--- a/src/scss/_images.scss
+++ b/src/scss/_images.scss
@@ -15,7 +15,7 @@
 //
 
 .figure-img {
-  margin-bottom: ($spacer / 2);
+  margin-bottom: ($spacer * 0.5);
 }
 
 .figure-caption {

--- a/src/scss/_popover.scss
+++ b/src/scss/_popover.scss
@@ -35,7 +35,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: $popover-arrow-height ($popover-arrow-width / 2) 0;
+    border-width: $popover-arrow-height ($popover-arrow-width * 0.5) 0;
   }
 
   .arrow::before {
@@ -60,7 +60,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: ($popover-arrow-width / 2) $popover-arrow-height ($popover-arrow-width / 2) 0;
+    border-width: ($popover-arrow-width * 0.5) $popover-arrow-height ($popover-arrow-width * 0.5) 0;
   }
 
   .arrow::before {
@@ -82,7 +82,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: 0 ($popover-arrow-width / 2) $popover-arrow-height ($popover-arrow-width / 2);
+    border-width: 0 ($popover-arrow-width * 0.5) $popover-arrow-height ($popover-arrow-width * 0.5);
   }
 
   .arrow::before {
@@ -114,7 +114,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: ($popover-arrow-width / 2) 0 ($popover-arrow-width / 2) $popover-arrow-height;
+    border-width: ($popover-arrow-width * 0.5) 0 ($popover-arrow-width * 0.5) $popover-arrow-height;
   }
 
   .arrow::before {

--- a/src/scss/_popover.scss
+++ b/src/scss/_popover.scss
@@ -97,7 +97,7 @@
   // This will remove the popover-header's border just below the arrow
   .popover-header::before {
     width: $popover-arrow-width;
-    margin-left: ($popover-arrow-width / -2);
+    margin-left: ($popover-arrow-width * -0.5);
     border-bottom: $popover-border-width solid $popover-header-bg;
   }
 }

--- a/src/scss/_tooltip.scss
+++ b/src/scss/_tooltip.scss
@@ -19,7 +19,7 @@
   padding: $tooltip-arrow-height 0;
 
   .arrow::before {
-    border-width: $tooltip-arrow-height ($tooltip-arrow-width / 2) 0;
+    border-width: $tooltip-arrow-height ($tooltip-arrow-width * 0.5) 0;
     border-top-color: $tooltip-arrow-color;
   }
 }
@@ -32,7 +32,7 @@
     height: $tooltip-arrow-width;
 
     &::before {
-      border-width: ($tooltip-arrow-width / 2) $tooltip-arrow-height ($tooltip-arrow-width / 2) 0;
+      border-width: ($tooltip-arrow-width * 0.5) $tooltip-arrow-height ($tooltip-arrow-width * 0.5) 0;
       border-right-color: $tooltip-arrow-color;
     }
   }
@@ -42,7 +42,7 @@
   padding: $tooltip-arrow-height 0;
 
   .arrow::before {
-    border-width: 0 ($tooltip-arrow-width / 2) $tooltip-arrow-height;
+    border-width: 0 ($tooltip-arrow-width * 0.5) $tooltip-arrow-height;
     border-bottom-color: $tooltip-arrow-color;
   }
 }
@@ -55,7 +55,7 @@
     height: $tooltip-arrow-width;
 
     &::before {
-      border-width: ($tooltip-arrow-width / 2) 0 ($tooltip-arrow-width / 2) $tooltip-arrow-height;
+      border-width: ($tooltip-arrow-width * 0.5) 0 ($tooltip-arrow-width * 0.5) $tooltip-arrow-height;
       border-left-color: $tooltip-arrow-color;
     }
   }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -602,7 +602,7 @@ $navbar-nav-link-padding-x: .625rem !default;
 
 // Navbar
 
-$navbar-padding-y:                  ($spacer / 2) !default;
+$navbar-padding-y:                  ($spacer * 0.5) !default;
 $navbar-padding-x:                  $spacer !default;
 
 $navbar-brand-font-size:            1rem !default;
@@ -610,7 +610,7 @@ $navbar-brand-font-size:            1rem !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
 $nav-link-height:                   $navbar-brand-font-size * $line-height-base !default;
 $navbar-brand-height:               ($font-size-base * $line-height-base + $nav-link-padding-y * 2) !default;
-$navbar-brand-padding-y:            ($navbar-brand-height - $nav-link-height) / 2 !default;
+$navbar-brand-padding-y:            ($navbar-brand-height - $nav-link-height) * 0.5 !default;
 
 $navbar-font-family:                $font-family-poppins-first !default;
 $navbar-toggler-padding-y:           .5rem !default;
@@ -675,10 +675,10 @@ $card-spacer-y:                 2.1875rem !default;
 $card-spacer-x:                 1.875rem !default;
 
 $card-header-spacer-x:          $card-spacer-x !default;
-$card-header-spacer-y:          ($card-spacer-y / 2) !default;
+$card-header-spacer-y:          ($card-spacer-y * 0.5) !default;
 
 $card-footer-spacer-x:          $card-spacer-x !default;
-$card-footer-spacer-y:          ($card-spacer-y / 2) !default;
+$card-footer-spacer-y:          ($card-spacer-y * 0.5) !default;
 
 $card-border-radius:            0.625rem !default;
 $card-inner-border-radius:      $card-border-radius !default;

--- a/src/scss/mixins/_nav-divider.scss
+++ b/src/scss/mixins/_nav-divider.scss
@@ -4,7 +4,7 @@
 
 @mixin nav-divider($color: #e5e5e5) {
   height: 0;
-  margin: ($spacer / 2) 0;
+  margin: ($spacer * 0.5) 0;
   overflow: hidden;
   border-top: 1px solid $color;
 }


### PR DESCRIPTION
fix deprecation warning by replacing all divisions with multiply 
`DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
`